### PR TITLE
Fix length complement check.

### DIFF
--- a/husky_base/src/horizon_legacy/Transport.cpp
+++ b/husky_base/src/horizon_legacy/Transport.cpp
@@ -277,7 +277,7 @@ namespace clearpath
           msg_len = rx_buf[1] + 3;
 
           /* Check for valid length */
-          if ((rx_buf[1] != ~rx_buf[2]) || (msg_len < Message::MIN_MSG_LENGTH))
+          if ((rx_buf[1] ^ rx_buf[2]) != 0xFF || (msg_len < Message::MIN_MSG_LENGTH))
           {
             counters[GARBLE_BYTES] += rx_inx;
             rx_inx = 0;


### PR DESCRIPTION
There's a subtle difference in how ~ is implemented in aarch64 which causes this check to fail. The new implementation should work on x86 and ARM.
