### PR TITLE
Another bitwise fix, now for x86.

### DIFF
--- a/husky_base/src/horizon_legacy/Transport.cpp
+++ b/husky_base/src/horizon_legacy/Transport.cpp
@@ -277,7 +277,8 @@ namespace clearpath
           msg_len = rx_buf[1] + 3;
 
           /* Check for valid length */
-          if ((rx_buf[1] ^ rx_buf[2]) != 0xFF || (msg_len < Message::MIN_MSG_LENGTH))
+          if (static_cast<unsigned char>(rx_buf[1] ^ rx_buf[2]) != 0xFF ||
+              (msg_len < Message::MIN_MSG_LENGTH))
           {
             counters[GARBLE_BYTES] += rx_inx;
             rx_inx = 0;


### PR DESCRIPTION
The real fix here would be switching the buffer to be `uint8_t` rather than `char`, but I'm nervous about impacts that could have elsewhere. This is a more contained fix that should restore functionality on x86.
