### PR TITLE
Add tf_prefix parameter for hardware interface

### DIFF
--- a/husky_base/include/husky_base/husky_hardware.h
+++ b/husky_base/include/husky_base/husky_hardware.h
@@ -95,6 +95,8 @@ private:
 
   double polling_timeout_;
 
+  std::string tf_prefix_;
+
   /**
   * Joint structure that is hooked to ros_control's InterfaceManager, to allow control via diff_drive_controller
   */

--- a/husky_base/src/husky_hardware.cpp
+++ b/husky_base/src/husky_hardware.cpp
@@ -58,6 +58,7 @@ namespace husky_base
     private_nh_.param<double>("max_accel", max_accel_, 5.0);
     private_nh_.param<double>("max_speed", max_speed_, 1.0);
     private_nh_.param<double>("polling_timeout_", polling_timeout_, 10.0);
+    private_nh_.param<std::string>("tf_prefix", tf_prefix_, "");
 
     std::string port;
     private_nh_.param<std::string>("port", port, "/dev/prolific");
@@ -113,8 +114,8 @@ namespace husky_base
   */
   void HuskyHardware::registerControlInterfaces()
   {
-    ros::V_string joint_names = boost::assign::list_of("front_left_wheel")
-      ("front_right_wheel")("rear_left_wheel")("rear_right_wheel");
+    ros::V_string joint_names = boost::assign::list_of(tf_prefix_ + "front_left_wheel")
+      (tf_prefix_ + "front_right_wheel")(tf_prefix_ + "rear_left_wheel")(tf_prefix_ + "rear_right_wheel");
     for (unsigned int i = 0; i < joint_names.size(); i++)
     {
       hardware_interface::JointStateHandle joint_state_handle(joint_names[i],


### PR DESCRIPTION
When using a robot description that uses a tf_prefix for the robot,
the joint names will be different than expected in the hardware interface.
This commits ads a tf_prefix parameter to the hardware node in order to pass
a tf_prefix into the node.

Obviously, this could be solved differently, e.g. by reading the joint names from the parameter server completely, I've seen that approach in other RobotHW implementations, as well. That would have the benefit of being completely flexible with the downside of adding an additional list parameter to the node.