### PR TITLE
Remove unnecessary PS4, Logitech udev rules.

### DIFF
--- a/husky_bringup/debian/udev
+++ b/husky_bringup/debian/udev
@@ -1,12 +1,2 @@
 # Udev rule for the Prolific Serial-to-USB adapter shipped standard with Husky
 SUBSYSTEMS=="usb", ATTRS{manufacturer}=="Prolific*", SYMLINK+="prolific prolific_$attr{devpath}", MODE="0666"
-
-# Udev rule for the Logitech controller previously shipped standard with Husky
-KERNEL=="js*", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c21f", SYMLINK="input/f710"
-
-# Udev rule for the PS4 controller now shipped with standard with Husky
-KERNEL=="js*", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="07dc", SYMLINK="input/ps4"
-KERNEL=="js*", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="07da", SYMLINK="input/ps4"
-
-# Alternate Udev rule for the PS4 controller (if it's detected as DualShock 4)
-KERNEL=="js*", ATTRS{idVendor}=="054C", ATTRS{idProduct}=="05C4", SYMLINK="input/ps4"


### PR DESCRIPTION
These were previously removed from Melodic; not sure why they were re-added for Noetic, but I suspect it was a copy-paste error