### PR TITLE
Use configurable laser prefix

### DIFF
--- a/husky_bringup/launch/lms1xx_config/lms1xx.launch
+++ b/husky_bringup/launch/lms1xx_config/lms1xx.launch
@@ -5,13 +5,13 @@
   <group if="$(arg lms1xx_enabled)">
     <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
       <param name="host" value="$(env HUSKY_LMS1XX_IP)" />
-      <param name="frame_id" value="base_laser" />
+      <param name="frame_id" value="$(optenv HUSKY_LMS1XX_PREFIX front)_laser" />
     </node>
   </group>
   <group if="$(arg lms1xx_secondary_enabled)">
     <node pkg="lms1xx" name="lms1xx_secondary" type="LMS1xx_node">
       <param name="host" value="$(env HUSKY_LMS1XX_SECONDARY_IP)" />
-      <param name="frame_id" value="rear_laser" />
+      <param name="frame_id" value="$(optenv HUSKY_LMS1XX_SECONDARY_PREFIX rear)_laser" />
     </node>
   </group>
 </launch>


### PR DESCRIPTION
husky_description supports changing the frame ID, but without being able to change the frame ID in the launch file you wind up with a broken tf
- https://github.com/husky/husky/blob/2c46d3b0d4815bdf4a8973d62439657155f831da/husky_description/urdf/husky.urdf.xacro#L35
- https://github.com/husky/husky/blob/2c46d3b0d4815bdf4a8973d62439657155f831da/husky_description/urdf/husky.urdf.xacro#L42

Also, the existing default "base_laser" is inconsistent with the latest husky_description.

IndoorNav, because of how Otto's implemented parts of it, currently requires the front & rear lidar frames to be `front_laser` and `rear_laser` respectively, so fixing this will also make IndoorNav easier to develop/maintain.